### PR TITLE
Implement ZF3 FactoryInterface __invoke method

### DIFF
--- a/src/StefanoDbProfiler/Collector/Service/DbCollectorFactory.php
+++ b/src/StefanoDbProfiler/Collector/Service/DbCollectorFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace StefanoDbProfiler\Collector\Service;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use StefanoDbProfiler\Collector\DbCollector;
@@ -9,6 +10,10 @@ use StefanoDbProfiler\Options\ModuleOptions;
 class DbCollectorFactory
     implements FactoryInterface
 {
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
+        return $this->createService($container);
+    }
+
     public function createService(ServiceLocatorInterface $serviceLocator) {
         $moduleOptions = $this->getModuleOptions($serviceLocator);
 

--- a/src/StefanoDbProfiler/Options/Service/ModuleOptionsFactory.php
+++ b/src/StefanoDbProfiler/Options/Service/ModuleOptionsFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace StefanoDbProfiler\Options\Service;
 
+use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use StefanoDbProfiler\Options\ModuleOptions;
@@ -8,6 +9,10 @@ use StefanoDbProfiler\Options\ModuleOptions;
 class ModuleOptionsFactory
     implements FactoryInterface
 {
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null) {
+        return $this->createService($container);
+    }
+
     public function createService(ServiceLocatorInterface $serviceLocator) {
         $config = $serviceLocator->get('Config');
         return new ModuleOptions($config['stefano_db_profiler']);


### PR DESCRIPTION
There are some changes in v3 Factories. ZF Factories are invokable and
therefore all factories which implement FactoryInterface must implement
__invoke method. Also ZF started using container-interop
ContainerInterface which replaced their previous ServiceLocatorInterface
in the method's definition. CreateService method should be deprecated in
the future.

As far as I know, this is the only thing had to be changed in this
library to support ZF3 completely.